### PR TITLE
Fix kometa not detecting recently installed Python

### DIFF
--- a/Kometa/main.sh
+++ b/Kometa/main.sh
@@ -212,4 +212,7 @@ main_fn() {
     esac
 }
 
+# Make sure $PATH is up to date
+# Fixes the issue of kometa failing to detect ~/.pyenv right after Python install
+source "$HOME/.profile"
 main_fn


### PR DESCRIPTION
Kometa throws the error below when our PATH doesn't have ~/.pyenv in its $PATH. When it is present in $PATH it doesn't throw error even with Python 3.14.2.
