### PR TITLE
Fix megatools installer: update domain from megous.com to xff.cz

### DIFF
--- a/Megatools/megatools-installer.sh
+++ b/Megatools/megatools-installer.sh
@@ -13,10 +13,10 @@ fi
 echo
 
 grab_latest_version() {
-    LATEST=$(curl -s https://megatools.megous.com/builds/LATEST)
+    LATEST=$(curl -s https://xff.cz/megatools/builds/LATEST)
     mkdir -p "$HOME"/.megatools-tmp
     cd "$HOME"/.megatools-tmp || exit
-    wget -qO megatools.tar.gz "https://megatools.megous.com/builds/builds/${LATEST}-linux-x86_64.tar.gz"
+    wget -qO megatools.tar.gz "https://xff.cz/megatools/builds/builds/${LATEST}-linux-x86_64.tar.gz"
     tar -xf megatools.tar.gz "${LATEST}-linux-x86_64/megatools" && mv "${LATEST}-linux-x86_64/megatools" "${HOME}/bin/"
     rm -rf "$HOME"/.megatools-tmp
 }


### PR DESCRIPTION
## Summary
- The megatools project moved its download domain from `megatools.megous.com` to `xff.cz/megatools`, breaking the installer
- Updated both URLs in `grab_latest_version()`: the `LATEST` version check and the tarball download

## Test plan
- [x] Run the installer on a slot and verify it fetches and installs the latest megatools binary